### PR TITLE
fix: support for multiple evdev devices #2

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -209,7 +209,7 @@ async fn udev_loop(mut state: State) {
     }
 }
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main(flavor = "multi_thread", worker_threads = 5)]
 async fn main() {
     SimpleLogger::new()
         .env()


### PR DESCRIPTION
the problem and the fix is all in discussion of issue #2.


Edit:
Im not sure that this is a permanent solution.
Im not damiliar with rust at all. But does change this mean that only 5 evdev devices are supported ?.

Ill do more tests tomorrow
