### PR TITLE
Add NixOS module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
 
         naersk-lib = pkgs.callPackage naersk { };
 
-        persistent-evdev = naersk-lib.buildPackage {
+        persistent-evdev-rs = naersk-lib.buildPackage {
           src = ./.;
           nativeBuildInputs = with pkgs; [
             pkg-config
@@ -35,14 +35,61 @@
           buildInputs = with pkgs; [
             systemd
           ];
+          postInstall = ''
+            mkdir -p $out/etc/udev/rules.d
+            cp udev/60-persistent-input-rs-uinput.rules $out/etc/udev/rules.d
+          '';
         };
       in
       {
+        nixosModules.persistent-evdev-rs =
+          {
+            config,
+            pkgs,
+            lib,
+            ...
+          }:
+          let
+            cfg = config.services.persistent-evdev-rs;
+
+            settingsFormat = pkgs.formats.json { };
+
+            configFile = settingsFormat.generate "persistent-evdev-rs-config" {
+              cache = "/var/cache/persistent-evdev-rs";
+              devices = lib.mapAttrs (virt: phys: "/dev/input/by-id/${phys}") cfg.devices;
+            };
+          in
+          {
+            options.services.persistent-evdev-rs = {
+              enable = lib.mkEnableOption "virtual input devices that persist even if the backing device is hotplugged";
+
+              devices = lib.mkOption {
+                default = { };
+                type = with lib.types; attrsOf str;
+              };
+            };
+
+            config = lib.mkIf cfg.enable {
+              systemd.services.persistent-evdev-rs = {
+                description = "Persistent evdev proxy";
+                wantedBy = [ "multi-user.target" ];
+
+                serviceConfig = {
+                  Restart = "on-failure";
+                  ExecStart = "${pkgs.persistent-evdev-rs}/bin/persistent-evdev-rs ${configFile}";
+                  CacheDirectory = "persistent-evdev-rs";
+                };
+              };
+
+              services.udev.packages = [ pkgs.persistent-evdev-rs ];
+            };
+          };
+
         packages = {
-          inherit persistent-evdev;
+          inherit persistent-evdev-rs;
         };
 
-        defaultPackage = self.packages.${system}.persistent-evdev;
+        defaultPackage = self.packages.${system}.persistent-evdev-rs;
 
         devShell = pkgs.mkShell {
           buildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -89,9 +89,8 @@
       {
         packages = {
           inherit persistent-evdev-rs;
+          default = persistent-evdev-rs;
         };
-
-        defaultPackage = self.packages.${system}.persistent-evdev-rs;
 
         devShell = pkgs.mkShell {
           buildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,52 @@
       nixpkgs,
       ...
     }:
-    flake-utils.lib.eachDefaultSystem (
+    {
+      nixosModules.persistent-evdev-rs =
+        {
+          config,
+          pkgs,
+          lib,
+          ...
+        }:
+        let
+          cfg = config.services.persistent-evdev-rs;
+          persistent-evdev-rs = self.packages.${pkgs.system}.persistent-evdev-rs;
+
+          settingsFormat = pkgs.formats.json { };
+
+          configFile = settingsFormat.generate "persistent-evdev-rs-config" {
+            cache = "/var/cache/persistent-evdev-rs";
+            devices = lib.mapAttrs (virt: phys: "/dev/input/by-id/${phys}") cfg.devices;
+          };
+        in
+        {
+          options.services.persistent-evdev-rs = {
+            enable = lib.mkEnableOption "virtual input devices that persist even if the backing device is hotplugged";
+
+            devices = lib.mkOption {
+              default = { };
+              type = with lib.types; attrsOf str;
+            };
+          };
+
+          config = lib.mkIf cfg.enable {
+            systemd.services.persistent-evdev-rs = {
+              description = "Persistent evdev proxy";
+              wantedBy = [ "multi-user.target" ];
+
+              serviceConfig = {
+                Restart = "on-failure";
+                ExecStart = "${persistent-evdev-rs}/bin/persistent-evdev-rs ${configFile}";
+                CacheDirectory = "persistent-evdev-rs";
+              };
+            };
+
+            services.udev.packages = [ persistent-evdev-rs ];
+          };
+        };
+    }
+    // flake-utils.lib.eachDefaultSystem (
       system:
       let
         pkgs = (import nixpkgs) {
@@ -42,49 +87,6 @@
         };
       in
       {
-        nixosModules.persistent-evdev-rs =
-          {
-            config,
-            pkgs,
-            lib,
-            ...
-          }:
-          let
-            cfg = config.services.persistent-evdev-rs;
-
-            settingsFormat = pkgs.formats.json { };
-
-            configFile = settingsFormat.generate "persistent-evdev-rs-config" {
-              cache = "/var/cache/persistent-evdev-rs";
-              devices = lib.mapAttrs (virt: phys: "/dev/input/by-id/${phys}") cfg.devices;
-            };
-          in
-          {
-            options.services.persistent-evdev-rs = {
-              enable = lib.mkEnableOption "virtual input devices that persist even if the backing device is hotplugged";
-
-              devices = lib.mkOption {
-                default = { };
-                type = with lib.types; attrsOf str;
-              };
-            };
-
-            config = lib.mkIf cfg.enable {
-              systemd.services.persistent-evdev-rs = {
-                description = "Persistent evdev proxy";
-                wantedBy = [ "multi-user.target" ];
-
-                serviceConfig = {
-                  Restart = "on-failure";
-                  ExecStart = "${pkgs.persistent-evdev-rs}/bin/persistent-evdev-rs ${configFile}";
-                  CacheDirectory = "persistent-evdev-rs";
-                };
-              };
-
-              services.udev.packages = [ pkgs.persistent-evdev-rs ];
-            };
-          };
-
         packages = {
           inherit persistent-evdev-rs;
         };


### PR DESCRIPTION
Added a simple NixOS module based on [persistent-evdev.nix](https://github.com/NixOS/nixpkgs/blob/d916df777523d75f7c5acca79946652f032f633e/nixos/modules/services/misc/persistent-evdev.nix) from the nixpkgs.